### PR TITLE
Enabled OpenGL in Samples/ControlCatalog.Desktop/Program.cs

### DIFF
--- a/samples/ControlCatalog.Desktop/Program.cs
+++ b/samples/ControlCatalog.Desktop/Program.cs
@@ -18,7 +18,8 @@ namespace ControlCatalog
         public static AppBuilder BuildAvaloniaApp()
             => AppBuilder.Configure<App>()
                 .LogToTrace()
-                .UsePlatformDetect();
+                .UsePlatformDetect()
+                .With(new Win32PlatformOptions() { UseWgl = true });    //enable use of OpenGL on Windows
 
         private static void ConfigureAssetAssembly(AppBuilder builder)
         {


### PR DESCRIPTION
## What does the pull request do?
This PR adds one line of code needed to make OpenGL work under Windows.  The modified code has been tested under Windows 10 and Ubuntu Linux.


## What is the current behavior?
Currently, when running the `ControlCatalog.Desktop` sample under Windows and selecting **OpenGL** from the left bar, no 3D teapot is displayed in the right pane.  This is because OpenGL isn't enabled in `Program.cs`.


## What is the updated/expected behavior with this PR?
When running the **OpenGL** Control a 3D teapot should be displayed and be controllable using the provided Slider Bars.


## How was the solution implemented (if it's not obvious)?
Added  `.With(new Win32PlatformOptions() { UseWgl = true })` to the `AppBuilder` Configuration to enable OpenGL when using Windows.

